### PR TITLE
Add delegated routing

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,38 +1,21 @@
 import React, { Component } from 'react';
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 import './App.css';
-import AppPage from './AppPage';
 import MainMenu from './components/main-menu/MainMenu';
 import Calendar from './components/calendar/Calendar';
 import Livefeed from './components/livefeed/Livefeed';
 import EmergencyResponseOrganization from './components/emergency-response-organization/EmergencyResponseOrganization';
-import BackupResources from './components/emergency-response-organization/backup-resources/BackupResources';
-import CompatibilityMatrix from './components/emergency-response-organization/compatibility-matrix/CompatibilityMatrix';
-import CompetenceStatus from './components/emergency-response-organization/competence-status/CompetenceStatus';
-import Deputies from './components/emergency-response-organization/deputies/Deputies';
-import EmergencyResponseTeams from './components/emergency-response-organization/emergency-response-teams/EmergencyResponseTeams';
 
-
-function appPageComponent(title, Component) {
-  return () => (
-    <AppPage title={title} Component={Component} />
-  );
-}
 
 class App extends Component {
   render() {
     return (
       <Router>
         <Switch>
-          <Route exact path="/" component={appPageComponent('Safetec Beredskapsportal', MainMenu)} />
-          <Route exact path="/calendar/" component={appPageComponent('Kalender', Calendar)} />
-          <Route exact path="/livefeed/" component={appPageComponent('Status beredskap - live feed', Livefeed)} />
-          <Route exact path="/emergency-response-organization/" component={appPageComponent('Beredskapsorganisasjon', EmergencyResponseOrganization)} />
-          <Route exact path="/emergency-response-organization/backup-resources/" component={appPageComponent('Reserveressurser', BackupResources)} />
-          <Route exact path="/emergency-response-organization/compatibility-matrix/" component={appPageComponent('Forenlighetsmatrise', CompatibilityMatrix)} />
-          <Route exact path="/emergency-response-organization/competence-status/" component={appPageComponent('Kompetansestatus', CompetenceStatus)} />
-          <Route exact path="/emergency-response-organization/deputies/" component={appPageComponent('Stedfortredere', Deputies)} />
-          <Route exact path="/emergency-response-organization/emergency-response-teams/" component={appPageComponent('Beredskapslag', EmergencyResponseTeams)} />
+          <Route exact path="/" component={MainMenu} />
+          <Route path="/calendar/" component={Calendar} />
+          <Route path="/livefeed/" component={Livefeed} />
+          <Route path="/emergency-response-organization/" component={EmergencyResponseOrganization} />
         </Switch>
       </Router>
     );

--- a/src/components/calendar/Calendar.js
+++ b/src/components/calendar/Calendar.js
@@ -9,6 +9,7 @@ import 'react-big-calendar/lib/css/react-big-calendar.css'
 import '../../styles/Calendar.css'
 import {isValidEvent, equalDates} from './../../helpers/calendar-helper'
 import {capitalizeFirstLetter} from "../../helpers/calendar-helper";
+import AppPage from '../shared/AppPage';
 
 moment.locale('nb');
 BigCalendar.momentLocalizer(moment);
@@ -163,32 +164,34 @@ export default class EmergencyResponsePortalCalendar extends Component {
   render() {
     const initTime = new Date(this.state.selectedDate.setHours(9));
     return (
-      <div className="container">
-        <BigCalendar
-          scrollToTime={initTime}
-          messages={norwegian_translations}
-          events={this.state.events}
-          popup={true}
-          views={['month', 'week', 'work_week', 'day', 'agenda']}
-          selectable={true}
-          formats={formats}
-          onSelectSlot={((slot) => this.slotClicked(slot))}
-          onSelectEvent={({start}) => this.eventClicked(start)}
-          components={{
-              dateCellWrapper: this.coloredDateCellWrapper,
-          }}
-        
-        />
-        <Paper className="paper-big">
-          {!this.state.showEventAdder ? (<SideDisplay events={this.state.events} date={this.state.selectedDate}
-                                                      onAddEventButtonClick={this.addEventButtonClicked}
-                                                      onDeleteButtonClick={this.deleteEvent}
-                                                      onChangeEvent={this.changeEventButtonClicked}
-                                                      onReviewButtonClick={this.reviewEvent}/>) :
-            <AddEvent date={this.state.selectedDate} eventToEdit={this.state.eventToEdit}
-                      onSaveButtonClick={this.saveEvent} deleteEvent={this.deleteEvent} onCancelClick={this.cancelButtonClicked} />}
-        </Paper>
-      </div>
+      <AppPage title="Kalender">
+        <div className="container">
+          <BigCalendar
+            scrollToTime={initTime}
+            messages={norwegian_translations}
+            events={this.state.events}
+            popup={true}
+            views={['month', 'week', 'work_week', 'day', 'agenda']}
+            selectable={true}
+            formats={formats}
+            onSelectSlot={((slot) => this.slotClicked(slot))}
+            onSelectEvent={({start}) => this.eventClicked(start)}
+            components={{
+                dateCellWrapper: this.coloredDateCellWrapper,
+            }}
+          
+          />
+          <Paper className="paper-big">
+            {!this.state.showEventAdder ? (<SideDisplay events={this.state.events} date={this.state.selectedDate}
+                                                        onAddEventButtonClick={this.addEventButtonClicked}
+                                                        onDeleteButtonClick={this.deleteEvent}
+                                                        onChangeEvent={this.changeEventButtonClicked}
+                                                        onReviewButtonClick={this.reviewEvent}/>) :
+              <AddEvent date={this.state.selectedDate} eventToEdit={this.state.eventToEdit}
+                        onSaveButtonClick={this.saveEvent} deleteEvent={this.deleteEvent} onCancelClick={this.cancelButtonClicked} />}
+          </Paper>
+        </div>
+      </AppPage>
     )
   }
 }

--- a/src/components/emergency-response-organization/EmergencyResponseOrganization.js
+++ b/src/components/emergency-response-organization/EmergencyResponseOrganization.js
@@ -6,13 +6,31 @@ import IconHierarchy from '../../icons/hierarchy.svg';
 import IconStats from '../../icons/stats-1.svg';
 import IconProfileGroup from '../../icons/profile-group.svg';
 import IconCogs from '../../icons/cogs.svg';
+import AppPage from '../shared/AppPage';
+import BackupResources from './backup-resources/BackupResources';
+import CompatibilityMatrix from './compatibility-matrix/CompatibilityMatrix';
+import CompetenceStatus from './competence-status/CompetenceStatus';
+import Deputies from './deputies/Deputies';
+import EmergencyResponseTeams from './emergency-response-teams/EmergencyResponseTeams';
+import { Switch, Route } from 'react-router-dom';
 
-export default () => (
-  <NavMenu>
-    <NavMenuItem name="Beredskapslag" icon={IconHierarchy} to="emergency-response-teams/" />
-    <NavMenuItem name="Kompetansestatus" icon={IconShield} to="competence-status/" />
-    <NavMenuItem name="Forenlighetsmatrise" icon={IconStats} to="compatibility-matrix/" />
-    <NavMenuItem name="Stedfortredere" icon={IconProfileGroup} to="deputies/" />
-    <NavMenuItem name="Reserveressurser" icon={IconCogs} to="backup-resources/" />
-  </NavMenu>
+export default ({ match }) => (
+  <Switch>
+    <Route exact path={match.path}>
+      <AppPage title="Beredskapsorganisasjon">
+        <NavMenu>
+          <NavMenuItem name="Beredskapslag" icon={IconHierarchy} to="emergency-response-teams/" />
+          <NavMenuItem name="Kompetansestatus" icon={IconShield} to="competence-status/" />
+          <NavMenuItem name="Forenlighetsmatrise" icon={IconStats} to="compatibility-matrix/" />
+          <NavMenuItem name="Stedfortredere" icon={IconProfileGroup} to="deputies/" />
+          <NavMenuItem name="Reserveressurser" icon={IconCogs} to="backup-resources/" />
+        </NavMenu>
+      </AppPage>
+    </Route>
+    <Route path={`${match.path}backup-resources/`} component={BackupResources} />
+    <Route path={`${match.path}compatibility-matrix/`} component={CompatibilityMatrix} />
+    <Route path={`${match.path}competence-status/`} component={CompetenceStatus} />
+    <Route path={`${match.path}deputies/`} component={Deputies} />
+    <Route path={`${match.path}emergency-response-teams/`} component={EmergencyResponseTeams} />
+  </Switch>
 );

--- a/src/components/livefeed/Livefeed.js
+++ b/src/components/livefeed/Livefeed.js
@@ -8,6 +8,7 @@ import Status from './Status';
 import Feed from './Feed';
 import PreparednessSummary from './PreparednessSummary';
 import ExternalResources from './ExternalResources';
+import AppPage from '../shared/AppPage';
 
 const feed = [
   {
@@ -132,35 +133,37 @@ class Livefeed extends React.Component {
     const { feed } = this.state;
 
     return (
-      <div className={classes.content}>
-        <Grid container spacing={24}>
-          <Grid item xs={12}>
-            <Paper className={classes.feedPaper}>
-              <Warning color="error" className={classes.feedWarning} />
-              <Feed
-                items={feed}
-                onSortEnd={this.onFeedSortEnd}
-                deleteItem={this.deleteFeedItem}
-                addItem={this.addFeedItem}
-                maxItems={7}
-                className={classes.feedList}
-              />
-            </Paper>
+      <AppPage title="Beredskapsstatus - Live feed">
+        <div className={classes.content}>
+          <Grid container spacing={24}>
+            <Grid item xs={12}>
+              <Paper className={classes.feedPaper}>
+                <Warning color="error" className={classes.feedWarning} />
+                <Feed
+                  items={feed}
+                  onSortEnd={this.onFeedSortEnd}
+                  deleteItem={this.deleteFeedItem}
+                  addItem={this.addFeedItem}
+                  maxItems={7}
+                  className={classes.feedList}
+                />
+              </Paper>
+            </Grid>
+            <Grid item xs={6}>
+              <Paper>
+                <PreparednessSummary teams={teams} />
+              </Paper>
+            </Grid>
+            <Grid item xs={6}>
+              <Paper>
+                <ExternalResources
+                  items={externalResources}
+                />
+              </Paper>
+            </Grid>
           </Grid>
-          <Grid item xs={6}>
-            <Paper>
-              <PreparednessSummary teams={teams} />
-            </Paper>
-          </Grid>
-          <Grid item xs={6}>
-            <Paper>
-              <ExternalResources
-                items={externalResources}
-              />
-            </Paper>
-          </Grid>
-        </Grid>
-      </div>
+        </div>
+      </AppPage>
     );
   }
 }

--- a/src/components/main-menu/MainMenu.js
+++ b/src/components/main-menu/MainMenu.js
@@ -4,13 +4,16 @@ import IconLivefeed from '../../icons/livefeed.svg';
 import IconShield from '../../icons/shield.svg';
 import NavMenu from '../shared/NavMenu';
 import NavMenuItem from '../shared/NavMenuItem';
+import AppPage from '../shared/AppPage';
 
 
 
 export default () => (
-  <NavMenu>
-    <NavMenuItem name="Kalender" icon={IconCalendar} to="calendar/" />
-    <NavMenuItem name="Live feed" icon={IconLivefeed} to="livefeed/" />
-    <NavMenuItem name="Beredskapsorganisasjon" icon={IconShield} to="emergency-response-organization/" />
-  </NavMenu>
+  <AppPage title="Safetec Beredskapsportal">
+    <NavMenu>
+      <NavMenuItem name="Kalender" icon={IconCalendar} to="calendar/" />
+      <NavMenuItem name="Live feed" icon={IconLivefeed} to="livefeed/" />
+      <NavMenuItem name="Beredskapsorganisasjon" icon={IconShield} to="emergency-response-organization/" />
+    </NavMenu>
+  </AppPage>
 );

--- a/src/components/shared/AppPage.js
+++ b/src/components/shared/AppPage.js
@@ -2,7 +2,7 @@ import React from 'react';
 import AppBar from '@material-ui/core/AppBar';
 import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
-import SafetecLogo from './icons/safetec_logo.png';
+import SafetecLogo from '../../icons/safetec_logo.png';
 import { withStyles } from '@material-ui/core';
 
 const styles = {
@@ -11,7 +11,7 @@ const styles = {
   },
 }
 
-const AppPage = ({ classes, title, Component }) => (
+const AppPage = ({ classes, title, children }) => (
   <React.Fragment>
     <AppBar position="static" color="default">
       <Toolbar>
@@ -27,7 +27,7 @@ const AppPage = ({ classes, title, Component }) => (
         </a>
       </Toolbar>
     </AppBar>
-    <Component />
+    {children}
   </React.Fragment>
 );
 


### PR DESCRIPTION
Our current routing strategy is not sustainable. App.js would explode in size and mixed concerns, especially when we add more complex URL matchers.

Instead of defining all the routing in one place, this approach moves the sub-routing concerns to page components. AppPage now has to be manually used by subcomponents. I believe this is generally a better approach as it will allow more dynamic titles and specific customisation on each page.